### PR TITLE
feat: implementacja UI glownego dashboardu closes #24

### DIFF
--- a/app/src/main/java/com/example/watir_iot_app/feature/dashboard/DashboardScreen.kt
+++ b/app/src/main/java/com/example/watir_iot_app/feature/dashboard/DashboardScreen.kt
@@ -1,18 +1,60 @@
 package com.example.watir_iot_app.feature.dashboard
 
+import android.graphics.drawable.Icon
+import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.width
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.PowerSettingsNew
+import androidx.compose.material.icons.filled.Thermostat
+import androidx.compose.material.icons.filled.WaterDrop
+import androidx.compose.material.icons.filled.Waves
+import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.unit.dp
+import com.example.watir_iot_app.feature.dashboard.components.SensorCard
 
 @Composable
 fun DashboardScreen() {
-    Box(
-        modifier = Modifier.fillMaxSize(),
-        contentAlignment = Alignment.Center
+    Column(
+        modifier = Modifier.fillMaxSize().padding(16.dp)
     ) {
-        Text(text = "Dashboard Screen - WATIR IoT")
+        Text(
+            text = "Twój Mikroklimat",
+            style = MaterialTheme.typography.headlineMedium,
+            fontWeight = FontWeight.Bold
+        )
+        Spacer(
+            modifier = Modifier.height(16.dp)
+        )
+        Row(
+            modifier = Modifier.fillMaxWidth(),
+            horizontalArrangement = Arrangement.spacedBy(16.dp)
+        ) {
+            SensorCard("Wilgotność", "60%", Icons.Default.WaterDrop, modifier = Modifier.weight(1f))
+            SensorCard("Temperatura", "22°C", Icons.Default.Thermostat, modifier = Modifier.weight(1f))
+        }
+        Spacer(
+            modifier = Modifier.height(16.dp)
+        )
+        Row(
+            modifier = Modifier.fillMaxWidth(),
+            horizontalArrangement = Arrangement.spacedBy(16.dp)
+        ) {
+            SensorCard("Stan Pompy", "Czuwa", Icons.Default.PowerSettingsNew, modifier = Modifier.weight(1f))
+            SensorCard("Zbiornik wody", "Pełny", Icons.Default.Waves, modifier = Modifier.weight(1f))
+        }
+
     }
 }

--- a/app/src/main/java/com/example/watir_iot_app/feature/dashboard/components/SensorCard.kt
+++ b/app/src/main/java/com/example/watir_iot_app/feature/dashboard/components/SensorCard.kt
@@ -1,0 +1,65 @@
+package com.example.watir_iot_app.feature.dashboard.components
+
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
+import androidx.compose.material3.Card
+import androidx.compose.material3.CardDefaults
+import androidx.compose.material3.Icon
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.vector.ImageVector
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.TextOverflow
+import androidx.compose.ui.unit.dp
+
+@Composable
+fun SensorCard(
+    title: String,
+    value: String,
+    icon: ImageVector,
+    modifier: Modifier = Modifier
+) {
+    Card(
+        modifier = modifier.fillMaxWidth(),
+        elevation = CardDefaults.cardElevation(defaultElevation = 4.dp)
+    ) {
+        Row(
+            modifier = Modifier.padding(16.dp).fillMaxWidth(),
+            verticalAlignment = Alignment.CenterVertically
+            ) {
+            Icon(
+                imageVector = icon,
+                contentDescription = title,
+                modifier = Modifier.size(40.dp),
+                tint = MaterialTheme.colorScheme.primary,
+                )
+            Spacer(
+                modifier = Modifier.width(16.dp)
+            )
+            Column{
+                Text(
+                    text = title,
+                    maxLines = 1,
+                    overflow = TextOverflow.Ellipsis,
+                    style = MaterialTheme.typography.bodyMedium,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant
+                )
+                Text(
+                    text = value,
+                    style = MaterialTheme.typography.headlineSmall,
+                    fontWeight = FontWeight.Bold
+                )
+            }
+
+        }
+    }
+
+}


### PR DESCRIPTION
Opis zmian
Zaimplementowałem główny widok Dashboardu (Issue #24), który służy jako centrum dowodzenia mikroklimatem w aplikacji WATIR IoT.

Co zostało zrobione:
Uniwersalny komponent SensorCard: Zbudowałem reużywalną kartę opartą na Material 3 (Card, Row, Column), która dynamicznie przyjmuje tytuł, wartość oraz ikonę.

Układ siatki (Grid): Stworzyłem responsywny układ 2x2 przy użyciu komponentów Column i Row z modyfikatorami rozkładającymi wagę elementów (weight).

UI/UX: Dodałem obsługę przepełnienia tekstu (TextOverflow.Ellipsis), aby zapobiec łamaniu się etykiet na mniejszych ekranach, oraz zadbałem o odpowiednie marginesy i typografię.

Dane startowe: Podpiąłem statyczne dane (hardcoded) gotowe do podmiany na strumienie danych z ViewModelu.

<img width="419" height="927" alt="image" src="https://github.com/user-attachments/assets/c9b402a5-49bb-47e3-b2f4-592d7cfce3f3" />
