### PR TITLE
feat(backend): optymalizacja bazy danych i retencja logów (#22)

### DIFF
--- a/backend/index.js
+++ b/backend/index.js
@@ -5,7 +5,13 @@ const { Pool } = require('pg');
 
 const app = express();
 app.use(cors());
-app.use(express.json()); // Do parsowania JSON z body
+app.use(express.json());
+
+// ==========================================
+// KONFIGURACJA RETENCJI — Issue #22
+// Maksymalna liczba rekordów na urządzenie
+// ==========================================
+const RETENTION_LIMIT = 1000;
 
 // Połączenie z PostgreSQL
 const pool = new Pool({
@@ -21,22 +27,59 @@ pool.connect()
   .catch(err => console.error('❌ Błąd połączenia z bazą:', err.stack));
 
 // ==========================================
+// FUNKCJA RETENCJI — Issue #22
+// Usuwa stare rekordy, zostawia ostatnie RETENTION_LIMIT
+// na urządzenie. Wywoływana po każdym INSERT.
+// ==========================================
+async function enforceRetention(device_id) {
+  try {
+    const result = await pool.query(
+      `DELETE FROM telemetry_logs
+       WHERE device_id = $1
+         AND id NOT IN (
+           SELECT id FROM telemetry_logs
+           WHERE device_id = $1
+           ORDER BY timestamp DESC
+           LIMIT $2
+         )`,
+      [device_id, RETENTION_LIMIT]
+    );
+    if (result.rowCount > 0) {
+      console.log(`🧹 Retencja [${device_id}]: usunięto ${result.rowCount} starych rekordów`);
+    }
+  } catch (err) {
+    // Retencja nie jest krytyczna — logujemy błąd, ale nie przerywamy działania
+    console.error('⚠️ Błąd retencji:', err.message);
+  }
+}
+
+// ==========================================
 // ENDPOINT 1: POST /api/telemetry (Dla ESP8266)
-// Odbiera JSON z ESP i zapisuje do bazy
+// Odbiera JSON z ESP i zapisuje do bazy,
+// następnie wymusza retencję dla tego urządzenia
 // ==========================================
 app.post('/api/telemetry', async (req, res) => {
   try {
     const data = req.body;
-    
+
+    // Walidacja wymaganych pól
+    if (!data.device_id || !data.sensors || !data.status || !data.servos) {
+      return res.status(400).json({
+        status: 'error',
+        message: 'Brakujące pola: wymagane device_id, sensors, status, servos'
+      });
+    }
+
     const query = `
-      INSERT INTO telemetry_logs 
-      (device_id, timestamp, temp, humidity, soil_moisture, water_level_cm, water_error, pump_active, pan, tilt) 
-      VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10) RETURNING *;
+      INSERT INTO telemetry_logs
+      (device_id, timestamp, temp, humidity, soil_moisture, water_level_cm, water_error, pump_active, pan, tilt)
+      VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10)
+      RETURNING *;
     `;
-    
-    const values =[
+
+    const values = [
       data.device_id,
-      data.timestamp || Math.floor(Date.now() / 1000), // Domyślnie aktualny czas UNIX
+      data.timestamp || Math.floor(Date.now() / 1000),
       data.sensors.temp,
       data.sensors.humidity,
       data.sensors.soil_moisture,
@@ -48,30 +91,171 @@ app.post('/api/telemetry', async (req, res) => {
     ];
 
     const result = await pool.query(query, values);
-    res.status(201).json({ status: "success", message: "Log zapisany poprawnie!", saved: result.rows[0] });
-    
+
+    // Retencja w tle — nie blokuje odpowiedzi dla ESP
+    enforceRetention(data.device_id);
+
+    res.status(201).json({
+      status: 'success',
+      message: 'Log zapisany poprawnie!',
+      saved: result.rows[0]
+    });
+
   } catch (error) {
     console.error(error);
-    res.status(500).json({ status: "error", message: "Błąd zapisu do bazy danych." });
+    res.status(500).json({ status: 'error', message: 'Błąd zapisu do bazy danych.' });
   }
 });
 
 // ==========================================
 // ENDPOINT 2: GET /api/telemetry (Dla Aplikacji)
-// Zwraca historię logów (np. ostatnie 50 wpisów)
+// Issue #22: dodano filtrowanie po device_id i limit
+//
+// Query params:
+//   device_id  — opcjonalne, filtruje po urządzeniu
+//   limit      — opcjonalne, domyślnie 50, max 500
+//
+// Przykłady:
+//   GET /api/telemetry
+//   GET /api/telemetry?device_id=WATIR_01
+//   GET /api/telemetry?device_id=WATIR_01&limit=100
 // ==========================================
 app.get('/api/telemetry', async (req, res) => {
   try {
-    const result = await pool.query('SELECT * FROM telemetry_logs ORDER BY timestamp DESC LIMIT 50');
-    res.status(200).json({ status: "success", data: result.rows });
+    const { device_id, limit } = req.query;
+    const safeLimit = Math.min(parseInt(limit) || 50, 500);
+
+    let result;
+
+    if (device_id) {
+      result = await pool.query(
+        `SELECT * FROM telemetry_logs
+         WHERE device_id = $1
+         ORDER BY timestamp DESC
+         LIMIT $2`,
+        [device_id, safeLimit]
+      );
+    } else {
+      result = await pool.query(
+        `SELECT * FROM telemetry_logs
+         ORDER BY timestamp DESC
+         LIMIT $1`,
+        [safeLimit]
+      );
+    }
+
+    res.status(200).json({ status: 'success', data: result.rows });
+
   } catch (error) {
     console.error(error);
-    res.status(500).json({ status: "error", message: "Błąd odczytu z bazy danych." });
+    res.status(500).json({ status: 'error', message: 'Błąd odczytu z bazy danych.' });
+  }
+});
+
+// ==========================================
+// ENDPOINT 3: GET /api/telemetry/stats (Nowy)
+// Zwraca statystyki retencji — pomocne do debugowania
+// i monitorowania rozmiaru bazy
+// ==========================================
+app.get('/api/telemetry/stats', async (req, res) => {
+  try {
+    const result = await pool.query(
+      `SELECT
+         device_id,
+         COUNT(*) AS total_records,
+         MIN(timestamp) AS oldest_timestamp,
+         MAX(timestamp) AS newest_timestamp,
+         ROUND(COUNT(*) * 100.0 / $1, 1) AS retention_usage_pct
+       FROM telemetry_logs
+       GROUP BY device_id
+       ORDER BY device_id`,
+      [RETENTION_LIMIT]
+    );
+
+    res.status(200).json({
+      status: 'success',
+      retention_limit: RETENTION_LIMIT,
+      devices: result.rows
+    });
+
+  } catch (error) {
+    console.error(error);
+    res.status(500).json({ status: 'error', message: 'Błąd pobierania statystyk.' });
+  }
+});
+
+// ==========================================
+// ENDPOINT 4: DELETE /api/telemetry (Nowy)
+// Ręczne wymuszenie retencji lub pełne czyszczenie
+//
+// Query params:
+//   device_id  — wymagane
+//   mode       — 'retain' (zostaw ostatnie N) lub 'purge' (wyczyść wszystko)
+// ==========================================
+app.delete('/api/telemetry', async (req, res) => {
+  try {
+    const { device_id, mode = 'retain' } = req.query;
+
+    if (!device_id) {
+      return res.status(400).json({
+        status: 'error',
+        message: 'Wymagany parametr: device_id'
+      });
+    }
+
+    let deletedCount;
+
+    if (mode === 'purge') {
+      const result = await pool.query(
+        'DELETE FROM telemetry_logs WHERE device_id = $1',
+        [device_id]
+      );
+      deletedCount = result.rowCount;
+    } else {
+      const result = await pool.query(
+        `DELETE FROM telemetry_logs
+         WHERE device_id = $1
+           AND id NOT IN (
+             SELECT id FROM telemetry_logs
+             WHERE device_id = $1
+             ORDER BY timestamp DESC
+             LIMIT $2
+           )`,
+        [device_id, RETENTION_LIMIT]
+      );
+      deletedCount = result.rowCount;
+    }
+
+    res.status(200).json({
+      status: 'success',
+      message: `Usunięto ${deletedCount} rekordów`,
+      device_id,
+      mode,
+      deleted: deletedCount
+    });
+
+  } catch (error) {
+    console.error(error);
+    res.status(500).json({ status: 'error', message: 'Błąd czyszczenia bazy.' });
+  }
+});
+
+// ==========================================
+// ENDPOINT 5: GET /api/plants (Profile roślin)
+// ==========================================
+app.get('/api/plants', async (req, res) => {
+  try {
+    const result = await pool.query('SELECT * FROM plant_profiles ORDER BY id');
+    res.status(200).json({ status: 'success', data: result.rows });
+  } catch (error) {
+    console.error(error);
+    res.status(500).json({ status: 'error', message: 'Błąd odczytu profili.' });
   }
 });
 
 // Start serwera
 const PORT = process.env.PORT || 3000;
 app.listen(PORT, () => {
-  console.log(`Serwer API działa na porcie http://localhost:${PORT}`);
+  console.log(`🌿 Serwer WATIR API działa na http://localhost:${PORT}`);
+  console.log(`📦 Limit retencji: ${RETENTION_LIMIT} rekordów na urządzenie`);
 });

--- a/backend/init.sql
+++ b/backend/init.sql
@@ -1,5 +1,10 @@
+-- ==========================================
+-- WATIR IoT — Inicjalizacja bazy danych
+-- Issue #22: Optymalizacja zapytań i retencja
+-- ==========================================
+
 -- Tabela 1: Logi Telemetryczne (Zrzuty z czujników ESP8266)
-CREATE TABLE telemetry_logs (
+CREATE TABLE IF NOT EXISTS telemetry_logs (
     id SERIAL PRIMARY KEY,
     device_id VARCHAR(50) NOT NULL,
     timestamp BIGINT NOT NULL,          -- UNIX Epoch z JSONa
@@ -15,14 +20,40 @@ CREATE TABLE telemetry_logs (
 );
 
 -- Tabela 2: Profile Roślin (Konfiguracja dla ESP8266)
-CREATE TABLE plant_profiles (
+CREATE TABLE IF NOT EXISTS plant_profiles (
     id SERIAL PRIMARY KEY,
-    name VARCHAR(50) NOT NULL,          
-    moisture_threshold INT NOT NULL,    
-    auto_watering BOOLEAN DEFAULT true, 
-    check_interval_ms INT DEFAULT 10000 
+    name VARCHAR(50) NOT NULL,
+    moisture_threshold INT NOT NULL,
+    auto_watering BOOLEAN DEFAULT true,
+    check_interval_ms INT DEFAULT 10000
 );
 
--- Wrzucamy testowy profil rośliny
+-- ==========================================
+-- INDEKSY — Issue #22: Optymalizacja zapytań
+-- ==========================================
+
+-- Indeks główny: backend zawsze robi ORDER BY timestamp DESC
+-- Największy zysk wydajnościowy przy dużej tabeli
+CREATE INDEX IF NOT EXISTS idx_telemetry_timestamp
+    ON telemetry_logs (timestamp DESC);
+
+-- Indeks pomocniczy: filtrowanie po urządzeniu (GET /api/telemetry?device_id=...)
+-- Potrzebny gdy w sieci jest więcej niż jedno urządzenie WATIR
+CREATE INDEX IF NOT EXISTS idx_telemetry_device_id
+    ON telemetry_logs (device_id);
+
+-- Indeks złożony: device_id + timestamp razem — najszybszy dla zapytań
+-- "ostatnie N rekordów z konkretnego urządzenia"
+CREATE INDEX IF NOT EXISTS idx_telemetry_device_timestamp
+    ON telemetry_logs (device_id, timestamp DESC);
+
+-- ==========================================
+-- DANE TESTOWE
+-- ==========================================
+
+-- Wrzucamy testowy profil rośliny (jeśli nie istnieje)
 INSERT INTO plant_profiles (name, moisture_threshold, auto_watering, check_interval_ms)
-VALUES ('Kaktus_Testowy', 200, true, 10000);
+SELECT 'Kaktus_Testowy', 200, true, 10000
+WHERE NOT EXISTS (
+    SELECT 1 FROM plant_profiles WHERE name = 'Kaktus_Testowy'
+);


### PR DESCRIPTION
## Co i dlaczego

Rozwiązuje #22

Bez indeksów PostgreSQL przy każdym zapytaniu z apki
skanuje całą tabelę od góry do dołu. Przy ESP wysyłającym
dane co sekundę tabela szybko rośnie i zapytania zaczynają
wyraźnie zwalniać. Indeksy to naprawiają.

Retencja zapobiega temu żeby baza nie rosła bez końca
— trzymamy ostatnie 1000 rekordów na urządzenie, reszta
jest automatycznie kasowana po każdym nowym wpisie.

## Co się zmieniło

**init.sql**
- 3 nowe indeksy: po timestamp, po device_id i indeks złożony
- CREATE TABLE i INSERT używają teraz IF NOT EXISTS
  żeby reinicjalizacja kontenera nie crashowała

**index.js**
- automatyczna retencja po każdym POST (działa w tle,
  ESP dostaje odpowiedź natychmiast)
- GET /api/telemetry przyjmuje ?device_id=WATIR_01&limit=100
- nowy GET /api/telemetry/stats — widać ile rekordów
  ma każde urządzenie i ile % limitu zajmuje
- nowy DELETE /api/telemetry — ręczne czyszczenie jeśli trzeba
- nowy GET /api/plants — przygotowanie pod issue #28
- walidacja body przy POST — 400 zamiast crasha

## Jak przetestować

1. `docker-compose restart api`
2. Otwórz w przeglądarce `http://localhost:3000/api/telemetry/stats`
   — powinno zwrócić `"retention_limit": 1000`
3. Wyślij testowy POST przez curl (przykład w opisie issue #22)
4. W DBeaver sprawdź indeksy:
   `SELECT indexname FROM pg_indexes WHERE tablename = 'telemetry_logs'`
   — powinny być 4 pozycje (PRIMARY KEY + 3 nowe)

## Uwaga dla reviewera

Na działającej bazie indeksy trzeba dodać ręcznie jednym
poleceniem — docker exec z init.sql nie działa na istniejącej
bazie. Dokładny skrypt jest w opisie issue #22.