### PR TITLE
Feature/issue 35 joystick UI

### DIFF
--- a/app/src/main/java/com/example/watir_iot_app/feature/dashboard/DashboardScreen.kt
+++ b/app/src/main/java/com/example/watir_iot_app/feature/dashboard/DashboardScreen.kt
@@ -15,6 +15,7 @@ import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
 import com.example.watir_iot_app.feature.dashboard.components.SensorCard
@@ -23,6 +24,7 @@ import com.example.watir_iot_app.viewmodel.WatirViewModel
 @Composable
 fun DashboardScreen(viewModel: WatirViewModel) {
     val latestData = viewModel.telemetryHistory.value.data.firstOrNull()
+
     val humidityText = latestData?.humidity?.let { "$it%" } ?: "--%"
     val soilMoistureText = latestData?.soil_moisture?.let { "$it%" } ?: "--%"
     val tempText = latestData?.temp?.let { "$it°C" } ?: "--°C"
@@ -34,6 +36,13 @@ fun DashboardScreen(viewModel: WatirViewModel) {
     } else {
         latestData?.water_level_cm?.let { "${it} cm" } ?: "Brak danych"
     }
+
+    // Paleta WATIR
+    val watirNavy = Color(0xFF102A43)
+    val watirBlue = Color(0xFF2EB4E6)
+    val watirGreen = Color(0xFF549E39)
+    val watirDarkRed = Color(0xFFB71C1C) // Ciemny, elegancki czerwony dla termometru
+
     Column(
         modifier = Modifier
             .fillMaxSize()
@@ -44,12 +53,45 @@ fun DashboardScreen(viewModel: WatirViewModel) {
             text = "Twój Mikroklimat",
             style = MaterialTheme.typography.headlineMedium,
             fontWeight = FontWeight.Bold,
+            color = watirNavy,
             modifier = Modifier.padding(bottom = 8.dp)
         )
-        SensorCard("Temperatura", tempText, Icons.Default.Thermostat, modifier = Modifier.fillMaxWidth())
-        SensorCard("Wilgotność powietrza", humidityText, Icons.Default.WaterDrop, modifier = Modifier.fillMaxWidth())
-        SensorCard("Wilgotność gleby", soilMoistureText, Icons.Default.Eco, modifier = Modifier.fillMaxWidth())
-        SensorCard("Poziom wody", waterText, Icons.Default.Waves, modifier = Modifier.fillMaxWidth())
-        SensorCard("Stan Pompy", pumpText, Icons.Default.PowerSettingsNew, modifier = Modifier.fillMaxWidth())
+
+        SensorCard(
+            title = "Temperatura",
+            value = tempText,
+            icon = Icons.Default.Thermostat,
+            iconTint = watirDarkRed,
+            modifier = Modifier.fillMaxWidth()
+        )
+        SensorCard(
+            title = "Wilgotność powietrza",
+            value = humidityText,
+            icon = Icons.Default.WaterDrop,
+            iconTint = watirBlue,
+            modifier = Modifier.fillMaxWidth()
+        )
+        SensorCard(
+            title = "Wilgotność gleby",
+            value = soilMoistureText,
+            icon = Icons.Default.Eco,
+            iconTint = watirGreen,
+            modifier = Modifier.fillMaxWidth()
+        )
+        SensorCard(
+            title = "Poziom wody",
+            value = waterText,
+            icon = Icons.Default.Waves,
+            iconTint = watirBlue,
+            valueColor = if (latestData?.water_error == true) Color(0xFFD32F2F) else watirNavy,
+            modifier = Modifier.fillMaxWidth()
+        )
+        SensorCard(
+            title = "Stan Pompy",
+            value = pumpText,
+            icon = Icons.Default.PowerSettingsNew,
+            iconTint = if (latestData?.pump_active == true) watirGreen else Color.Gray,
+            modifier = Modifier.fillMaxWidth()
+        )
     }
 }

--- a/app/src/main/java/com/example/watir_iot_app/feature/dashboard/DashboardScreen.kt
+++ b/app/src/main/java/com/example/watir_iot_app/feature/dashboard/DashboardScreen.kt
@@ -37,11 +37,10 @@ fun DashboardScreen(viewModel: WatirViewModel) {
         latestData?.water_level_cm?.let { "${it} cm" } ?: "Brak danych"
     }
 
-    // Paleta WATIR
     val watirNavy = Color(0xFF102A43)
     val watirBlue = Color(0xFF2EB4E6)
     val watirGreen = Color(0xFF549E39)
-    val watirDarkRed = Color(0xFFB71C1C) // Ciemny, elegancki czerwony dla termometru
+    val watirDarkRed = Color(0xFFB71C1C)
 
     Column(
         modifier = Modifier

--- a/app/src/main/java/com/example/watir_iot_app/feature/dashboard/components/SensorCard.kt
+++ b/app/src/main/java/com/example/watir_iot_app/feature/dashboard/components/SensorCard.kt
@@ -27,13 +27,13 @@ fun SensorCard(
     value: String,
     icon: ImageVector,
     modifier: Modifier = Modifier,
-    iconTint: Color = Color(0xFF102A43), // Domyślnie Granat WATIR
-    valueColor: Color = Color(0xFF102A43) // Domyślnie Granat WATIR
+    iconTint: Color = Color(0xFF102A43),
+    valueColor: Color = Color(0xFF102A43)
 ) {
     Card(
         modifier = modifier.fillMaxWidth(),
         colors = CardDefaults.cardColors(
-            containerColor = Color.White // Wymuszamy białe tło karty dla lepszego kontrastu
+            containerColor = Color.White
         ),
         elevation = CardDefaults.cardElevation(defaultElevation = 4.dp)
     ) {
@@ -45,7 +45,7 @@ fun SensorCard(
                 imageVector = icon,
                 contentDescription = title,
                 modifier = Modifier.size(40.dp),
-                tint = iconTint // Używamy przypisanego koloru (np. z logo)
+                tint = iconTint
             )
             Spacer(
                 modifier = Modifier.width(16.dp)
@@ -62,7 +62,7 @@ fun SensorCard(
                     text = value,
                     style = MaterialTheme.typography.headlineSmall,
                     fontWeight = FontWeight.Bold,
-                    color = valueColor // Używamy przypisanego koloru (np. czerwony dla braku wody)
+                    color = valueColor
                 )
             }
         }

--- a/app/src/main/java/com/example/watir_iot_app/feature/dashboard/components/SensorCard.kt
+++ b/app/src/main/java/com/example/watir_iot_app/feature/dashboard/components/SensorCard.kt
@@ -15,6 +15,7 @@ import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.vector.ImageVector
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextOverflow
@@ -25,41 +26,45 @@ fun SensorCard(
     title: String,
     value: String,
     icon: ImageVector,
-    modifier: Modifier = Modifier
+    modifier: Modifier = Modifier,
+    iconTint: Color = Color(0xFF102A43), // Domyślnie Granat WATIR
+    valueColor: Color = Color(0xFF102A43) // Domyślnie Granat WATIR
 ) {
     Card(
         modifier = modifier.fillMaxWidth(),
+        colors = CardDefaults.cardColors(
+            containerColor = Color.White // Wymuszamy białe tło karty dla lepszego kontrastu
+        ),
         elevation = CardDefaults.cardElevation(defaultElevation = 4.dp)
     ) {
         Row(
             modifier = Modifier.padding(16.dp).fillMaxWidth(),
             verticalAlignment = Alignment.CenterVertically
-            ) {
+        ) {
             Icon(
                 imageVector = icon,
                 contentDescription = title,
                 modifier = Modifier.size(40.dp),
-                tint = MaterialTheme.colorScheme.primary,
-                )
+                tint = iconTint // Używamy przypisanego koloru (np. z logo)
+            )
             Spacer(
                 modifier = Modifier.width(16.dp)
             )
-            Column{
+            Column {
                 Text(
                     text = title,
                     maxLines = 1,
                     overflow = TextOverflow.Ellipsis,
                     style = MaterialTheme.typography.bodyMedium,
-                    color = MaterialTheme.colorScheme.onSurfaceVariant
+                    color = Color.Gray
                 )
                 Text(
                     text = value,
                     style = MaterialTheme.typography.headlineSmall,
-                    fontWeight = FontWeight.Bold
+                    fontWeight = FontWeight.Bold,
+                    color = valueColor // Używamy przypisanego koloru (np. czerwony dla braku wody)
                 )
             }
-
         }
     }
-
 }

--- a/app/src/main/java/com/example/watir_iot_app/feature/joystick/JoystickScreen.kt
+++ b/app/src/main/java/com/example/watir_iot_app/feature/joystick/JoystickScreen.kt
@@ -45,7 +45,6 @@ fun JoystickScreen(watirViewModel: WatirViewModel) {
     var expanded by remember { mutableStateOf(false) }
     var selectedPlant by remember { mutableStateOf<PlantProfile?>(null) }
 
-    // Paleta Kolorów z Logo WATIR
     val watirNavy = Color(0xFF102A43)
     val watirBlue = Color(0xFF2EB4E6)
     val watirGreen = Color(0xFF549E39)
@@ -64,8 +63,6 @@ fun JoystickScreen(watirViewModel: WatirViewModel) {
         )
 
         Spacer(modifier = Modifier.height(32.dp))
-
-        // Joystick - dodaliśmy rozmiar (size) żeby go powiększyć
         VirtualJoystick(
             modifier = Modifier.size(240.dp),
             onMove = { x, y ->
@@ -91,7 +88,7 @@ fun JoystickScreen(watirViewModel: WatirViewModel) {
             onExpandedChange = { expanded = !expanded },
             modifier = Modifier
                 .fillMaxWidth()
-                .padding(horizontal = 24.dp) // Piękne marginesy boczne
+                .padding(horizontal = 24.dp)
         ) {
             OutlinedTextField(
                 value = selectedPlant?.name ?: "Wybierz profil",
@@ -102,7 +99,7 @@ fun JoystickScreen(watirViewModel: WatirViewModel) {
                     .menuAnchor(type = MenuAnchorType.PrimaryNotEditable, enabled = true)
                     .fillMaxWidth(),
                 colors = ExposedDropdownMenuDefaults.outlinedTextFieldColors(
-                    focusedBorderColor = watirBlue, // Niebieski akcent przy kliknięciu
+                    focusedBorderColor = watirBlue,
                     unfocusedBorderColor = watirNavy.copy(alpha = 0.5f)
                 ),
                 shape = MaterialTheme.shapes.medium
@@ -129,15 +126,14 @@ fun JoystickScreen(watirViewModel: WatirViewModel) {
         Row(
             modifier = Modifier
                 .fillMaxWidth()
-                .padding(horizontal = 24.dp), // Zrównane marginesy z dropdownem
+                .padding(horizontal = 24.dp),
             horizontalArrangement = Arrangement.spacedBy(16.dp)
         ) {
             Button(
                 onClick = {
-                    // Miejsce na akcję podlewania
                 },
                 modifier = Modifier
-                    .weight(0.4f) // Zajmuje 40% szerokości
+                    .weight(0.4f)
                     .height(50.dp),
                 colors = ButtonDefaults.buttonColors(containerColor = watirBlue),
                 shape = MaterialTheme.shapes.medium
@@ -157,10 +153,10 @@ fun JoystickScreen(watirViewModel: WatirViewModel) {
                 },
                 enabled = selectedPlant != null,
                 modifier = Modifier
-                    .weight(0.6f) // Zajmuje 60% szerokości (bo ma dłuższy tekst)
+                    .weight(0.6f)
                     .height(50.dp),
                 colors = ButtonDefaults.buttonColors(
-                    containerColor = watirGreen, // Kolor sukcesu / rośliny
+                    containerColor = watirGreen,
                     disabledContainerColor = Color.LightGray
                 ),
                 shape = MaterialTheme.shapes.medium

--- a/app/src/main/java/com/example/watir_iot_app/feature/joystick/JoystickScreen.kt
+++ b/app/src/main/java/com/example/watir_iot_app/feature/joystick/JoystickScreen.kt
@@ -3,12 +3,13 @@ package com.example.watir_iot_app.feature.joystick
 import android.widget.Toast
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
-import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
 import androidx.compose.material3.Button
 import androidx.compose.material3.ButtonDefaults
 import androidx.compose.material3.DropdownMenuItem
@@ -26,9 +27,10 @@ import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
-import androidx.lifecycle.viewmodel.compose.viewModel
 import com.example.watir_iot_app.data.model.PlantProfile
 import com.example.watir_iot_app.feature.joystick.components.VirtualJoystick
 import com.example.watir_iot_app.viewmodel.WatirViewModel
@@ -43,17 +45,29 @@ fun JoystickScreen(watirViewModel: WatirViewModel) {
     var expanded by remember { mutableStateOf(false) }
     var selectedPlant by remember { mutableStateOf<PlantProfile?>(null) }
 
+    // Paleta Kolorów z Logo WATIR
+    val watirNavy = Color(0xFF102A43)
+    val watirBlue = Color(0xFF2EB4E6)
+    val watirGreen = Color(0xFF549E39)
+
     Column(
         modifier = Modifier.fillMaxSize(),
         verticalArrangement = Arrangement.Center,
-        horizontalAlignment = Alignment.CenterHorizontally)
-    {
+        horizontalAlignment = Alignment.CenterHorizontally
+    ) {
 
-        Text("Sterowanie Ręczne", style = MaterialTheme.typography.headlineMedium)
+        Text(
+            text = "Sterowanie Ręczne",
+            style = MaterialTheme.typography.headlineMedium,
+            fontWeight = FontWeight.Bold,
+            color = watirNavy
+        )
 
-        Spacer(modifier = Modifier.height(24.dp))
+        Spacer(modifier = Modifier.height(32.dp))
 
+        // Joystick - dodaliśmy rozmiar (size) żeby go powiększyć
         VirtualJoystick(
+            modifier = Modifier.size(240.dp),
             onMove = { x, y ->
                 watirViewModel.onJoystickMoved(x, y)
             },
@@ -62,16 +76,22 @@ fun JoystickScreen(watirViewModel: WatirViewModel) {
             }
         )
 
-        Spacer(modifier = Modifier.height(32.dp))
+        Spacer(modifier = Modifier.height(48.dp))
 
-        Text("Wybierz roślinę do kalibracji", style = MaterialTheme.typography.labelLarge)
+        Text(
+            text = "Wybierz roślinę do kalibracji",
+            style = MaterialTheme.typography.titleMedium,
+            color = watirNavy
+        )
 
-        Spacer(modifier = Modifier.height(8.dp))
+        Spacer(modifier = Modifier.height(12.dp))
 
         ExposedDropdownMenuBox(
             expanded = expanded,
             onExpandedChange = { expanded = !expanded },
-            modifier = Modifier.fillMaxWidth()
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(horizontal = 24.dp) // Piękne marginesy boczne
         ) {
             OutlinedTextField(
                 value = selectedPlant?.name ?: "Wybierz profil",
@@ -81,7 +101,11 @@ fun JoystickScreen(watirViewModel: WatirViewModel) {
                 modifier = Modifier
                     .menuAnchor(type = MenuAnchorType.PrimaryNotEditable, enabled = true)
                     .fillMaxWidth(),
-                colors = ExposedDropdownMenuDefaults.outlinedTextFieldColors()
+                colors = ExposedDropdownMenuDefaults.outlinedTextFieldColors(
+                    focusedBorderColor = watirBlue, // Niebieski akcent przy kliknięciu
+                    unfocusedBorderColor = watirNavy.copy(alpha = 0.5f)
+                ),
+                shape = MaterialTheme.shapes.medium
             )
 
             ExposedDropdownMenu(
@@ -90,7 +114,7 @@ fun JoystickScreen(watirViewModel: WatirViewModel) {
             ) {
                 plantProfiles.forEach { plant ->
                     DropdownMenuItem(
-                        text = { Text(plant.name) },
+                        text = { Text(plant.name, color = watirNavy) },
                         onClick = {
                             selectedPlant = plant
                             expanded = false
@@ -100,14 +124,26 @@ fun JoystickScreen(watirViewModel: WatirViewModel) {
             }
         }
 
-        Spacer(modifier = Modifier.height(24.dp))
+        Spacer(modifier = Modifier.height(32.dp))
 
         Row(
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(horizontal = 24.dp), // Zrównane marginesy z dropdownem
             horizontalArrangement = Arrangement.spacedBy(16.dp)
         ) {
-            Button(onClick = {
-
-            }) {Text("Podlej") }
+            Button(
+                onClick = {
+                    // Miejsce na akcję podlewania
+                },
+                modifier = Modifier
+                    .weight(0.4f) // Zajmuje 40% szerokości
+                    .height(50.dp),
+                colors = ButtonDefaults.buttonColors(containerColor = watirBlue),
+                shape = MaterialTheme.shapes.medium
+            ) {
+                Text("Podlej", fontWeight = FontWeight.Bold)
+            }
 
             Button(
                 onClick = {
@@ -120,13 +156,16 @@ fun JoystickScreen(watirViewModel: WatirViewModel) {
                     }
                 },
                 enabled = selectedPlant != null,
-                modifier = Modifier.weight(1f),
+                modifier = Modifier
+                    .weight(0.6f) // Zajmuje 60% szerokości (bo ma dłuższy tekst)
+                    .height(50.dp),
                 colors = ButtonDefaults.buttonColors(
-                    containerColor = MaterialTheme.colorScheme.secondary
+                    containerColor = watirGreen, // Kolor sukcesu / rośliny
+                    disabledContainerColor = Color.LightGray
                 ),
-                contentPadding = PaddingValues(12.dp)
+                shape = MaterialTheme.shapes.medium
             ) {
-                Text("Zapisz pozycje dla rośliny")
+                Text("Zapisz pozycję", fontWeight = FontWeight.Bold)
             }
         }
     }

--- a/app/src/main/java/com/example/watir_iot_app/feature/joystick/components/VirtualJoystick.kt
+++ b/app/src/main/java/com/example/watir_iot_app/feature/joystick/components/VirtualJoystick.kt
@@ -11,37 +11,46 @@ import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.geometry.Offset
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.drawscope.Stroke
 import androidx.compose.ui.input.pointer.pointerInput
-import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.layout.onSizeChanged
 import androidx.compose.ui.unit.dp
-
 
 @Composable
 fun VirtualJoystick(
+    modifier: Modifier = Modifier,
     onMove: (xPercent: Float, yPercent: Float) -> Unit,
     onStop: () -> Unit
 ) {
     var thumbOffset by remember { mutableStateOf(Offset.Zero) }
-    val maxRadius = 150f
+    var maxRadius by remember { mutableStateOf(1f) } // Obliczany dynamicznie!
 
-    Canvas(modifier =
-        Modifier
-            .size(300.dp)
-            .pointerInput(Unit){
+    // Kolory z logo WATIR
+    val watirNavy = Color(0xFF102A43)
+    val watirBlue = Color(0xFF2EB4E6)
+
+    Canvas(
+        modifier = modifier
+            .size(240.dp) // Domyślny rozmiar (zostanie nadpisany, jeśli podano inny z zewnątrz)
+            .onSizeChanged { size ->
+                // Super ważna poprawka: dynamiczny promień dostosowany do każdego ekranu!
+                maxRadius = (size.width.coerceAtMost(size.height) / 2f)
+            }
+            .pointerInput(Unit) {
                 detectDragGestures(
                     onDragEnd = {
                         thumbOffset = Offset.Zero
+                        onStop() // UWAGA: Naprawiony błąd! Teraz silniki na pewno się zatrzymają.
                     }
-                ){ change, dragAmount->
-
+                ) { change, dragAmount ->
                     change.consume()
                     val newOffset = thumbOffset + dragAmount
                     val distance = newOffset.getDistance()
 
-                    if(distance <= maxRadius){
+                    // Trygonometria: nie pozwalamy kropce wyjść poza koło
+                    if (distance <= maxRadius) {
                         thumbOffset = newOffset
-                    }
-                    else{
+                    } else {
                         thumbOffset = newOffset / distance * maxRadius
                     }
 
@@ -51,14 +60,23 @@ fun VirtualJoystick(
 
                     onMove(xPercent, yPercent)
                 }
-            }) {
+            }
+    ) {
+        // 1. Baza joysticka (delikatne granatowe tło)
         drawCircle(
-            color = Color.LightGray,
+            color = watirNavy.copy(alpha = 0.05f),
             radius = maxRadius
         )
+        // 2. Obwódka bazy (wyraźniejsza)
         drawCircle(
-            color = Color.Blue,
-            radius = 50f,
+            color = watirNavy.copy(alpha = 0.2f),
+            radius = maxRadius,
+            style = Stroke(width = 4f)
+        )
+        // 3. "Grzybek" (piękny błękitny kciuk do sterowania)
+        drawCircle(
+            color = watirBlue,
+            radius = maxRadius * 0.35f, // Grzybek zajmuje zawsze proporcjonalnie 35% bazy
             center = center + thumbOffset
         )
     }

--- a/app/src/main/java/com/example/watir_iot_app/feature/joystick/components/VirtualJoystick.kt
+++ b/app/src/main/java/com/example/watir_iot_app/feature/joystick/components/VirtualJoystick.kt
@@ -23,38 +23,31 @@ fun VirtualJoystick(
     onStop: () -> Unit
 ) {
     var thumbOffset by remember { mutableStateOf(Offset.Zero) }
-    var maxRadius by remember { mutableStateOf(1f) } // Obliczany dynamicznie!
-
-    // Kolory z logo WATIR
+    var maxRadius by remember { mutableStateOf(1f) }
     val watirNavy = Color(0xFF102A43)
     val watirBlue = Color(0xFF2EB4E6)
 
     Canvas(
         modifier = modifier
-            .size(240.dp) // Domyślny rozmiar (zostanie nadpisany, jeśli podano inny z zewnątrz)
+            .size(240.dp)
             .onSizeChanged { size ->
-                // Super ważna poprawka: dynamiczny promień dostosowany do każdego ekranu!
                 maxRadius = (size.width.coerceAtMost(size.height) / 2f)
             }
             .pointerInput(Unit) {
                 detectDragGestures(
                     onDragEnd = {
                         thumbOffset = Offset.Zero
-                        onStop() // UWAGA: Naprawiony błąd! Teraz silniki na pewno się zatrzymają.
+                        onStop()
                     }
                 ) { change, dragAmount ->
                     change.consume()
                     val newOffset = thumbOffset + dragAmount
                     val distance = newOffset.getDistance()
-
-                    // Trygonometria: nie pozwalamy kropce wyjść poza koło
                     if (distance <= maxRadius) {
                         thumbOffset = newOffset
                     } else {
                         thumbOffset = newOffset / distance * maxRadius
                     }
-
-                    // Obliczamy wychylenie od -1.0 do 1.0
                     val xPercent = thumbOffset.x / maxRadius
                     val yPercent = thumbOffset.y / maxRadius
 
@@ -62,21 +55,18 @@ fun VirtualJoystick(
                 }
             }
     ) {
-        // 1. Baza joysticka (delikatne granatowe tło)
         drawCircle(
             color = watirNavy.copy(alpha = 0.05f),
             radius = maxRadius
         )
-        // 2. Obwódka bazy (wyraźniejsza)
         drawCircle(
             color = watirNavy.copy(alpha = 0.2f),
             radius = maxRadius,
             style = Stroke(width = 4f)
         )
-        // 3. "Grzybek" (piękny błękitny kciuk do sterowania)
         drawCircle(
             color = watirBlue,
-            radius = maxRadius * 0.35f, // Grzybek zajmuje zawsze proporcjonalnie 35% bazy
+            radius = maxRadius * 0.35f,
             center = center + thumbOffset
         )
     }

--- a/app/src/main/java/com/example/watir_iot_app/feature/settings/SettingsScreen.kt
+++ b/app/src/main/java/com/example/watir_iot_app/feature/settings/SettingsScreen.kt
@@ -58,7 +58,6 @@ fun SettingsScreen(viewModel: WatirViewModel) {
     var thresholdInput by remember { mutableStateOf("") }
     var intervalInput by remember { mutableStateOf("") }
 
-    // Paleta WATIR
     val watirNavy = Color(0xFF102A43)
     val watirBlue = Color(0xFF2EB4E6)
     val watirGreen = Color(0xFF549E39)

--- a/app/src/main/java/com/example/watir_iot_app/feature/settings/SettingsScreen.kt
+++ b/app/src/main/java/com/example/watir_iot_app/feature/settings/SettingsScreen.kt
@@ -14,12 +14,15 @@ import androidx.compose.material.icons.filled.Delete
 import androidx.compose.material.icons.filled.Edit
 import androidx.compose.material3.AlertDialog
 import androidx.compose.material3.Button
+import androidx.compose.material3.ButtonDefaults
 import androidx.compose.material3.DropdownMenuItem
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.ExposedDropdownMenuBox
 import androidx.compose.material3.ExposedDropdownMenuDefaults
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.MenuAnchorType
 import androidx.compose.material3.OutlinedTextField
 import androidx.compose.material3.Text
 import androidx.compose.material3.TextButton
@@ -30,7 +33,9 @@ import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
 import com.example.watir_iot_app.data.model.PlantProfile
 import com.example.watir_iot_app.viewmodel.WatirViewModel
@@ -48,15 +53,21 @@ fun SettingsScreen(viewModel: WatirViewModel) {
     var showDialog by remember { mutableStateOf(false) }
     var isEditing by remember { mutableStateOf(false) }
     var editId by remember { mutableStateOf(0) }
-    
+
     var nameInput by remember { mutableStateOf("") }
     var thresholdInput by remember { mutableStateOf("") }
     var intervalInput by remember { mutableStateOf("") }
 
+    // Paleta WATIR
+    val watirNavy = Color(0xFF102A43)
+    val watirBlue = Color(0xFF2EB4E6)
+    val watirGreen = Color(0xFF549E39)
+    val watirRed = Color(0xFFD32F2F)
+
     if (showDialog) {
         AlertDialog(
             onDismissRequest = { showDialog = false },
-            title = { Text(if (isEditing) "Edytuj profil" else "Nowy profil") },
+            title = { Text(if (isEditing) "Edytuj profil" else "Nowy profil", color = watirNavy, fontWeight = FontWeight.Bold) },
             text = {
                 Column {
                     OutlinedTextField(
@@ -83,6 +94,7 @@ fun SettingsScreen(viewModel: WatirViewModel) {
             },
             confirmButton = {
                 TextButton(
+                    colors = ButtonDefaults.textButtonColors(contentColor = watirNavy),
                     onClick = {
                         val threshold = thresholdInput.toIntOrNull() ?: 50
                         val interval = intervalInput.toIntOrNull() ?: 10000
@@ -118,11 +130,14 @@ fun SettingsScreen(viewModel: WatirViewModel) {
                         }
                     }
                 ) {
-                    Text("Zapisz")
+                    Text("Zapisz", fontWeight = FontWeight.Bold)
                 }
             },
             dismissButton = {
-                TextButton(onClick = { showDialog = false }) {
+                TextButton(
+                    colors = ButtonDefaults.textButtonColors(contentColor = Color.Gray),
+                    onClick = { showDialog = false }
+                ) {
                     Text("Anuluj")
                 }
             }
@@ -135,23 +150,27 @@ fun SettingsScreen(viewModel: WatirViewModel) {
             value = ipInput,
             onValueChange = { ipInput = it },
             label = { Text("Server IP") },
-            modifier = Modifier.fillMaxWidth()
+            modifier = Modifier.fillMaxWidth(),
+            shape = MaterialTheme.shapes.medium
         )
 
         Spacer(modifier = Modifier.height(8.dp))
 
         Button(
             onClick = { viewModel.connectToServer(ipInput) },
-            modifier = Modifier.fillMaxWidth()
+            modifier = Modifier.fillMaxWidth().height(50.dp),
+            colors = ButtonDefaults.buttonColors(containerColor = watirNavy),
+            shape = MaterialTheme.shapes.medium
         ) {
-            Text("Connect")
+            Text("Connect", fontWeight = FontWeight.Bold)
         }
 
         Spacer(modifier = Modifier.height(16.dp))
 
         Text(
-            text = if (viewModel.isConnected.value) "Status: Connected"
-            else "Status: Disconnected"
+            text = if (viewModel.isConnected.value) "Status: Connected" else "Status: Disconnected",
+            color = if (viewModel.isConnected.value) watirGreen else watirRed,
+            fontWeight = FontWeight.Bold
         )
 
         Spacer(modifier = Modifier.height(32.dp))
@@ -161,7 +180,7 @@ fun SettingsScreen(viewModel: WatirViewModel) {
             horizontalArrangement = Arrangement.SpaceBetween,
             verticalAlignment = Alignment.CenterVertically
         ) {
-            Text("Profile Roślin")
+            Text("Profile Roślin", style = MaterialTheme.typography.titleLarge, fontWeight = FontWeight.Bold, color = watirNavy)
             IconButton(onClick = {
                 isEditing = false
                 nameInput = ""
@@ -169,7 +188,7 @@ fun SettingsScreen(viewModel: WatirViewModel) {
                 intervalInput = "10000"
                 showDialog = true
             }) {
-                Icon(Icons.Default.Add, contentDescription = "Dodaj profil")
+                Icon(Icons.Default.Add, contentDescription = "Dodaj profil", tint = watirNavy)
             }
         }
 
@@ -188,7 +207,12 @@ fun SettingsScreen(viewModel: WatirViewModel) {
                     trailingIcon = {
                         ExposedDropdownMenuDefaults.TrailingIcon(expanded = expanded)
                     },
-                    modifier = Modifier.menuAnchor().fillMaxWidth()
+                    modifier = Modifier.menuAnchor(type = MenuAnchorType.PrimaryNotEditable, enabled = true).fillMaxWidth(),
+                    colors = ExposedDropdownMenuDefaults.outlinedTextFieldColors(
+                        focusedBorderColor = watirBlue,
+                        unfocusedBorderColor = watirNavy.copy(alpha = 0.5f)
+                    ),
+                    shape = MaterialTheme.shapes.medium
                 )
 
                 ExposedDropdownMenu(
@@ -197,7 +221,7 @@ fun SettingsScreen(viewModel: WatirViewModel) {
                 ) {
                     plants.forEach { plant ->
                         DropdownMenuItem(
-                            text = { Text(plant.name) },
+                            text = { Text(plant.name, color = watirNavy) },
                             onClick = {
                                 selectedPlant = plant
                                 expanded = false
@@ -218,7 +242,7 @@ fun SettingsScreen(viewModel: WatirViewModel) {
                         showDialog = true
                     }
                 }) {
-                    Icon(Icons.Default.Edit, contentDescription = "Edytuj profil")
+                    Icon(Icons.Default.Edit, contentDescription = "Edytuj profil", tint = watirBlue)
                 }
                 IconButton(onClick = {
                     selectedPlant?.let { plant ->
@@ -232,12 +256,12 @@ fun SettingsScreen(viewModel: WatirViewModel) {
                         )
                     }
                 }) {
-                    Icon(Icons.Default.Delete, contentDescription = "Usuń profil")
+                    Icon(Icons.Default.Delete, contentDescription = "Usuń profil", tint = watirRed)
                 }
             }
         }
 
-        Spacer(modifier = Modifier.height(8.dp))
+        Spacer(modifier = Modifier.height(16.dp))
 
         Button(
             onClick = {
@@ -254,9 +278,11 @@ fun SettingsScreen(viewModel: WatirViewModel) {
                 }
             },
             enabled = selectedPlant != null,
-            modifier = Modifier.fillMaxWidth()
+            modifier = Modifier.fillMaxWidth().height(50.dp),
+            colors = ButtonDefaults.buttonColors(containerColor = watirNavy),
+            shape = MaterialTheme.shapes.medium
         ) {
-            Text("Zastosuj profil na ESP32")
+            Text("Zastosuj profil na ESP32", fontWeight = FontWeight.Bold)
         }
     }
 }


### PR DESCRIPTION
W ramach realizacji zadania #35 przeprowadziłem gruntowny lifting wizualny aplikacji, aby była ona spójna z identyfikacją wizualną marki WATIR.

Główne zmiany:

Implementacja palety kolorów: Wprowadziłem firmowe barwy (Navy #102A43, Blue #2EB4E6, Green #549E39, Dark Red #B71C1C) w całej aplikacji.

JoystickScreen: * Powiększenie komponentu VirtualJoystick dla lepszej ergonomii.

Dodanie responsywnych marginesów i wyrównanie przycisków akcji.

Zmiana kolorystyki przycisków na zgodną z brandbookiem.

Fix: Poprawiono błąd w VirtualJoystick.kt – dodano wywołanie onStop() przy onDragEnd, co zapobiega blokowaniu się silników po puszczeniu joysticka.

DashboardScreen:

Przebudowa layoutu: usunięcie podstawowego szarego tła na rzecz czystych, nowoczesnych kart (SensorCard).

Zastosowanie dedykowanych kolorów dla poszczególnych sensorów (w tym specjalny, ciemnoczerwony akcent dla ikony temperatury).

SettingsScreen:

Ujednolicenie stylistyki pól tekstowych i przycisków.

Dodanie czytelnych oznaczeń statusu połączenia (zielony/czerwony).

Dopasowanie kolorystyki ikon zarządzania profilami roślin.
<img width="410" height="916" alt="image" src="https://github.com/user-attachments/assets/9ec25adf-5b63-414b-9d12-5b972730d1c4" />
<img width="410" height="912" alt="image" src="https://github.com/user-attachments/assets/4bd41706-5998-4824-bf7a-4046d46ce80c" />
<img width="415" height="915" alt="image" src="https://github.com/user-attachments/assets/3905e814-71b4-400e-8a8f-9b83c5964ad6" />
